### PR TITLE
Archnet #154 - ImageMagick buildpack adjustments

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,6 +62,7 @@ cat > $INSTALL_DIR/policy.xml <<EOF
 <policymap>
   <policy domain="delegate" rights="none" pattern="*" />
   <policy domain="delegate" rights="all" pattern="gs" />
+  <policy domain="delegate" rights="all" pattern="mpeg:decode" />
   <policy domain="coder" rights="none" pattern="*" />
   <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,JPG,PNG,WEBP,PS,XPS,PDF,MP4,MPEG,MPG,MOV,LABEL}" />
 </policymap>

--- a/bin/compile
+++ b/bin/compile
@@ -63,9 +63,24 @@ cat > $INSTALL_DIR/policy.xml <<EOF
   <policy domain="delegate" rights="none" pattern="*" />
   <policy domain="delegate" rights="all" pattern="gs" />
   <policy domain="coder" rights="none" pattern="*" />
-  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,JPG,PNG,WEBP,PS,XPS,PDF,MP4,MOV,LABEL}" />
+  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,JPG,PNG,WEBP,PS,XPS,PDF,MP4,MPEG,MPG,MOV,LABEL}" />
 </policymap>
 EOF
+
+echo "-----> Writing log file"
+cat > $INSTALL_DIR/log.xml <<EOF
+<logmap>
+  <log events="exception"/>
+  <log output="file"/>
+  <log filename="ImageMagick-%g.log"/>
+  <log generations="3"/>
+  <log limit="2000"/>
+  <log format="%t %r %u %v %d %c[%p]: %m/%f/%l/%d\n  %e"/>
+</logmap>
+EOD
+
+echo "-----> Copying delegates.xml"
+cp $INSTALL_DIR/etc/ImageMagick-7/delegates.xml $INSTALL_DIR
 
 # update PATH and LD_LIBRARY_PATH
 echo "-----> Updating environment variables"


### PR DESCRIPTION
This pull request fixes a bug that was causing an error when trying to upload videos to Archnet via the librarian interface. The issue was caused by the `policy.xml` file not allowing the `mpeg:decode` delegate. After resolving that, the issue still persisted. This was because the `delegates.xml` file could not be found.

The solution here was two fold:

- Update the `policy.xml` file to allow the `mpeg:decode` delegate
- Update the script to copy the `delegates.xml` file to the `INSTALL_DIR`