### PR TITLE
Archnet #154 - Video uploads

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,6 @@ cat > $INSTALL_DIR/policy.xml <<EOF
 <policymap>
   <policy domain="delegate" rights="none" pattern="*" />
   <policy domain="delegate" rights="all" pattern="gs" />
-  <policy domain="delegate" rights="all" pattern="mpeg:decode" />
   <policy domain="coder" rights="none" pattern="*" />
   <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,JPG,PNG,WEBP,PS,XPS,PDF,MP4,MPEG,MPG,MOV,LABEL}" />
 </policymap>
@@ -79,9 +78,6 @@ cat > $INSTALL_DIR/log.xml <<EOF
   <log format="%t %r %u %v %d %c[%p]: %m/%f/%l/%d\n  %e"/>
 </logmap>
 EOD
-
-echo "-----> Copying delegates.xml"
-cp $INSTALL_DIR/etc/ImageMagick-7/delegates.xml $INSTALL_DIR
 
 # update PATH and LD_LIBRARY_PATH
 echo "-----> Updating environment variables"


### PR DESCRIPTION
This pull request reverts the delegates changes made previously. Instead of delegating to FFMPEG, we'll use the Transcoder processor to pull the image from a video.

See the [Archnet](https://github.com/performant-software/archnet/pull/170) pull request.